### PR TITLE
feat: Added PFC support for Arista

### DIFF
--- a/mfd_switchmanagement/connections/ssh.py
+++ b/mfd_switchmanagement/connections/ssh.py
@@ -91,7 +91,9 @@ class SSHSwitchConnection(BaseSwitchConnection):
 
     def _check_connection(self) -> Optional[bool]:
         """Check connection to switch."""
-        connection_status = self._connection.is_alive()
+        connection_status = (
+            self._connection.remote_conn.transport.is_alive()
+        )  # check if transport layer of channel of connection is active
         if connection_status:
             logger.log(level=log_levels.MODULE_DEBUG, msg="Connection established.")
             return connection_status

--- a/sphinx-doc/conf.py
+++ b/sphinx-doc/conf.py
@@ -55,7 +55,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "MFD-Switchmanagement"
-project_copyright =  """Copyright (C) 2025 Intel Corporation
+project_copyright = """Copyright (C) 2025 Intel Corporation
 SPDX-License-Identifier: MIT"""
 copyright = project_copyright  # noqa
 author = "Intel Corporation"

--- a/tests/unit/test_mfd_switchmanagement/test_connections/test_ssh.py
+++ b/tests/unit/test_mfd_switchmanagement/test_connections/test_ssh.py
@@ -21,6 +21,7 @@ class TestSSHSwitchConnection:
         }
         ssh_connection = SSHSwitchConnection(**params)
         ssh_connection._connection = mocker.create_autospec(Netmiko)
+        ssh_connection._connection.remote_conn = mocker.Mock()
         mocker.stopall()
         return ssh_connection
 
@@ -48,7 +49,7 @@ class TestSSHSwitchConnection:
 
     def test__check_connection_connection_established(self, ssh_connection, mocker):
         log_debug = mocker.patch("mfd_switchmanagement.connections.ssh.logger.log")
-        ssh_connection._connection.is_alive = mocker.Mock(return_value=True)
+        ssh_connection._connection.remote_conn.transport.is_alive = mocker.Mock(return_value=True)
         return_value = ssh_connection._check_connection()
         expected_value = True
         log_debug.assert_called_once_with(level=log_levels.MODULE_DEBUG, msg="Connection established.")
@@ -56,7 +57,7 @@ class TestSSHSwitchConnection:
 
     def test__check_connection_connection_not_established(self, ssh_connection, mocker):
         log_debug = mocker.patch("mfd_switchmanagement.connections.ssh.logger.log")
-        ssh_connection._connection.is_alive = mocker.Mock(return_value=False)
+        ssh_connection._connection.remote_conn.transport.is_alive = mocker.Mock(return_value=False)
         return_value = ssh_connection._check_connection()
         expected_value = None
         log_debug.assert_called_once_with(level=log_levels.MODULE_DEBUG, msg="Connection not established.")


### PR DESCRIPTION
Fixes #2
This pull request introduces significant enhancements to the Arista switch management module, focusing on new configuration capabilities for DCBX, LLDP, trunking, and flow control, as well as improvements in connection handling and test coverage. The most important changes are grouped into functional enhancements, connection improvements, and testing updates.

### Functional Enhancements
* Added new methods in `mfd_switchmanagement/vendors/arista/base.py` to configure DCBX settings (`configure_dcbx`, `configure_dcbx_qos_map`, `configure_dcbx_ets_traffic_class`), LLDP (`configure_lldp`), trunking (`configure_trunking`), flow control (`disable_flowcontrol`), and priority flow control (`configure_priority_flow_control`). These methods provide robust support for managing advanced switch features.
* Introduced `configure_pfc_userspace` and `disable_pfc_userspace` methods to streamline enabling and disabling Priority Flow Control (PFC) configurations on interfaces.

### Connection Improvements
* Updated `_check_connection` in `mfd_switchmanagement/connections/ssh.py` to use `is_active()` on the transport layer for more accurate connection status checks.
* Replaced the use of `BaseSwitchConnection` with `SSHSwitchConnection` in `tests/unit/test_mfd_switchmanagement/test_vendors/test_arista/test_arista.py` to align with the updated connection handling logic. [[1]](diffhunk://#diff-dc161aed57ba47ec5a472a8616afa47e29261bb60776908dfa77ab12d60e1cd2L8-R8) [[2]](diffhunk://#diff-dc161aed57ba47ec5a472a8616afa47e29261bb60776908dfa77ab12d60e1cd2L20-R20)

### Testing Updates
* Added comprehensive unit tests for the newly introduced methods, ensuring proper validation and functionality for DCBX, LLDP, trunking, flow control, and PFC configurations.
* Enhanced test coverage for DCBX QoS map and ETS traffic class configurations by verifying specific commands sent to the switch.

These updates significantly enhance the capabilities and reliability of the Arista switch management module while maintaining robust test coverage.