### PR TITLE
fix: Add get_port_by_mac for DellOS9

### DIFF
--- a/tests/unit/test_mfd_switchmanagement/test_vendors/test_dell/test_dell_os9/test_base.py
+++ b/tests/unit/test_mfd_switchmanagement/test_vendors/test_dell/test_dell_os9/test_base.py
@@ -1,0 +1,47 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: MIT
+
+from pytest import fixture, raises
+from textwrap import dedent
+
+from mfd_switchmanagement import DellOS9
+from mfd_switchmanagement.exceptions import SwitchException
+
+
+class TestDellOS9:
+    """Class for DellOS9 tests."""
+
+    @fixture
+    def switch(self, mocker) -> DellOS9:
+        switch = DellOS9.__new__(DellOS9)
+        switch.__init__ = mocker.create_autospec(switch.__init__, return_value=None)
+        return switch
+
+    def test_get_port_by_mac(self, switch, mocker):
+        """Test get_port_by_mac method."""
+        switch._connection = mocker.Mock()
+        out = """
+        Codes: *N - VLT Peer Synced MAC
+        *I - Internal MAC Address used for Inter Process Communication
+        VlanId     Mac Address           Type          Interface        State
+         1      aa:bb:cc:dd:ee:ff       Dynamic         Te 0/32         Active
+        """
+        switch._connection.send_command = mocker.Mock(return_value=dedent(out))
+        assert switch.get_port_by_mac("aa:bb:cc:dd:ee:ff") == "Te 0/32"
+
+    def test_get_port_by_mac_not_found(self, switch, mocker):
+        """Test get_port_by_mac method when MAC address is not found."""
+        switch._connection = mocker.Mock()
+        out = """
+        Codes: *N - VLT Peer Synced MAC
+        *I - Internal MAC Address used for Inter Process Communication
+        VlanId     Mac Address           Type          Interface        State
+        """
+        switch._connection.send_command = mocker.Mock(return_value=dedent(out))
+        with raises(SwitchException, match="Could not find port for MAC address aa:bb:cc:dd:ee:ff"):
+            switch.get_port_by_mac("aa:bb:cc:dd:ee:ff")
+
+    def test_get_port_by_mac_invalid_mac(self, switch):
+        """Test get_port_by_mac method with invalid MAC address."""
+        with raises(ValueError, match="Incorrect MAC address: ZZ:ZZ:ZZ:ZZ:ZZ:ZZ"):
+            switch.get_port_by_mac("ZZ:ZZ:ZZ:ZZ:ZZ:ZZ")


### PR DESCRIPTION
This pull request adds new functionality to the Dell OS9 switch management module by introducing a method to retrieve the port name associated with a given MAC address, along with comprehensive unit tests to ensure its reliability. The changes enhance both the feature set and the test coverage of the codebase.

**New Feature: Port Lookup by MAC Address**
* Added the `get_port_by_mac` method to the `DellOS9` class in `dell_os9/base.py`, which retrieves the port name for a specified MAC address, including error handling for invalid or unknown MACs.

**Testing Enhancements**
* Created new unit tests in `test_base.py` to verify the behavior of `get_port_by_mac`, covering successful lookup, MAC address not found, and invalid MAC address scenarios.