### PR TITLE
fix: set NDK PFC bandwidth to 50% per traffic class

### DIFF
--- a/mfd_switchmanagement/vendors/dell/dell_os10/base.py
+++ b/mfd_switchmanagement/vendors/dell/dell_os10/base.py
@@ -1027,7 +1027,7 @@ class DellOS10(DellOS9):
 
         :param port: port of switch
         """
-        self.create_qos_policy([90, 10, 0, 0, 0, 0, 0, 0], [0, 0, 0, 1, 0, 0, 0, 0], "100")
+        self.create_qos_policy([50, 50, 0, 0, 0, 0, 0, 0], [0, 0, 0, 1, 0, 0, 0, 0], "100")
         self.set_port_bw_by_tc(port, suffix="100")
         self.set_port_pfc_by_tc(port, qos_priority=None, pfc="on")
         self.set_port_dcbx_version(port, mode="ieee")

--- a/tests/unit/test_mfd_switchmanagement/test_vendors/test_dell/test_dell_os10/test_base.py
+++ b/tests/unit/test_mfd_switchmanagement/test_vendors/test_dell/test_dell_os10/test_base.py
@@ -1225,7 +1225,7 @@ class TestDellOS10:
         switch.configure_pfc_ndk(port)
 
         # Assert
-        switch.create_qos_policy.assert_called_once_with([90, 10, 0, 0, 0, 0, 0, 0], [0, 0, 0, 1, 0, 0, 0, 0], "100")
+        switch.create_qos_policy.assert_called_once_with([50, 50, 0, 0, 0, 0, 0, 0], [0, 0, 0, 1, 0, 0, 0, 0], "100")
         switch.set_port_bw_by_tc.assert_called_once_with(port, suffix="100")
         switch.set_port_pfc_by_tc.assert_called_once_with(port, qos_priority=None, pfc="on")
         switch.set_port_dcbx_version.assert_called_once_with(port, mode="ieee")


### PR DESCRIPTION
Update configure_pfc_ndk to distribute bandwidth equally (50/50) across both traffic classes instead of the previous 90/10 split. Update corresponding unit test assertion to match new values.